### PR TITLE
Updated .gitmodules for https protocol

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,18 +1,18 @@
 [submodule "extern/bfjs"]
 	path = extern/bfjs
-	url = git://github.com/replit/bfjs.git
+	url = https://github.com/replit/bfjs.git
 [submodule "extern/emoticoffee"]
 	path = extern/emoticoffee
-	url = git://github.com/replit/emoticoffee.git
+	url = https://github.com/replit/emoticoffee.git
 [submodule "extern/lol-coffee"]
 	path = extern/lol-coffee
-	url = git://github.com/replit/lol-coffee.git
+	url = https://github.com/replit/lol-coffee.git
 [submodule "extern/unlambda-coffee"]
 	path = extern/unlambda-coffee
-	url = git://github.com/replit/unlambda-coffee.git
+	url = https://github.com/replit/unlambda-coffee.git
 [submodule "extern/apl"]
 	path = extern/apl
-	url = git://github.com/ngn/apl.git
+	url = https://github.com/ngn/apl.git
 [submodule "extern/biwascheme"]
 	path = extern/biwascheme
 	url = https://github.com/amasad/biwascheme.git


### PR DESCRIPTION
git protocol is blocked/not allowed in institution/organization. Changed submodule repository to use https protocol instead of git.
