### PR TITLE
UglifyJS as a dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,10 @@ A sandboxed polyglot browser REPL.
 Using npm :
 `sudo npm install -g coffee-script`
 
+##### [UglifyJS](https://github.com/mishoo/UglifyJS)
+Using npm :
+`sudo npm install -g uglify-js` then `export PATH=$PATH:/usr/local/lib/node_modules/uglify-js/bin/`
+
 #### Getting the source
 ##### Cloning the repository
 `git clone git://github.com/replit/jsrepl.git`


### PR DESCRIPTION
I had to install uglify-js to be able to build jsrepl.js because of this error:

```
Minifying tmp/engines/coffeescript-default.js failed:
Command failed: /bin/sh: 1: uglifyjs: not found
```
